### PR TITLE
Fix Python3 forwards compatibility

### DIFF
--- a/corelib/install.py
+++ b/corelib/install.py
@@ -25,6 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from __future__ import print_function
 import sys
 import os
 import shutil
@@ -40,12 +41,12 @@ if len(sys.argv) > 1:
       pkg = True
       version = arg[5:]
     else:
-      print "install.py [-pkg=version]"
-      print ""
-      print "  Install Crayfish C++ library"
-      print ""
-      print "  Arguments:"
-      print "  -pkg      Create .zip package for distribution instead of installation"
+      print("install.py [-pkg=version]")
+      print("")
+      print("  Install Crayfish C++ library")
+      print("")
+      print("  Arguments:")
+      print("  -pkg      Create .zip package for distribution instead of installation")
       sys.exit(0)
 
 build_file_cpp = os.path.join("..", "plugin", file_cpp)
@@ -55,14 +56,14 @@ if pkg:
   import zipfile
   with zipfile.ZipFile(os.path.join("..", zipfilename), "w", zipfile.ZIP_DEFLATED) as z:
     z.write(build_file_cpp, file_cpp)
-  print "Written " + zipfilename
+  print("Written " + zipfilename)
 
 else:
   plugin_dir = os.path.expanduser(os.path.join("~", ".qgis2", "python", "plugins", "crayfish"))
-  
+
   if not os.path.exists(plugin_dir):
     os.makedirs(plugin_dir)
 
   shutil.copy(build_file_cpp, plugin_dir)
-  print "Written " + file_cpp + " to " + plugin_dir
+  print("Written " + file_cpp + " to " + plugin_dir)
 

--- a/install.py
+++ b/install.py
@@ -25,6 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from __future__ import print_function
 import os
 import platform
 import sys
@@ -33,7 +34,7 @@ extra_install_args = ""
 if len(sys.argv) == 2 and sys.argv[1].startswith("-pkg="):
   extra_install_args = " " + sys.argv[1]
 
-print "Installing C++ library..."
+print("Installing C++ library...")
 os.chdir('corelib')
 if platform.system() == "Windows":
     os.system('qmake -spec win32-msvc2010 "CONFIG+=release"')
@@ -43,6 +44,6 @@ else:
     os.system('make')
 os.system('python install.py' + extra_install_args)
 
-print "Installing plugin..."
+print("Installing plugin...")
 os.chdir('../plugin')
 os.system('python install.py' + extra_install_args)

--- a/plugin/crayfish.py
+++ b/plugin/crayfish.py
@@ -106,7 +106,7 @@ class Mesh:
     self.lib = lib
     handle = self.lib.CF_LoadMesh(path)
     if handle is None:
-      raise ValueError, last_load_status() #, path)
+      raise ValueError(last_load_status()) #, path)
     assert handle not in Mesh.handles
     Mesh.handles[handle] = weakref.ref(self)
     self.handle = ctypes.c_void_p(handle)
@@ -157,7 +157,7 @@ class Mesh:
 
   def load_data(self, path):
     if not self.lib.CF_Mesh_loadDataSet(self.handle, path):
-      raise ValueError, last_load_status()
+      raise ValueError(last_load_status())
 
   def extent(self):
     xmin,ymin = ctypes.c_double(), ctypes.c_double()
@@ -188,7 +188,7 @@ class DataSet(object):
   def __init__(self, handle):
     self.lib = lib
     if handle is None:
-      raise ValueError, handle
+      raise ValueError(handle)
     assert handle not in DataSet.handles
     DataSet.handles[handle] = weakref.ref(self)
     self.handle = ctypes.c_void_p(handle)
@@ -257,7 +257,7 @@ class Output(object):
   def __init__(self, handle):
     self.lib = lib
     if handle is None:
-      raise ValueError, handle
+      raise ValueError(handle)
     assert handle not in Output.handles
     Output.handles[handle] = weakref.ref(self)
     self.handle = ctypes.c_void_p(handle)
@@ -329,7 +329,7 @@ class Value(object):
     elif value is None:
       pass # do nothing
     else:
-      raise ValueError, "unknown type of value"
+      raise ValueError("unknown type of value")
 
   def value(self):
     t = self.lib.CF_V_type(self.handle)
@@ -348,7 +348,7 @@ class Value(object):
       self.lib.CF_V_toColorMap(self.handle, cm.handle)
       return cm
     else:
-      raise ValueError, "unknown type in value"
+      raise ValueError("unknown type in value")
 
   def __del__(self):
     self.lib.CF_V_destroy(self.handle)
@@ -469,7 +469,7 @@ class ColorMap(object):
 
   def item(self, index):
     if index < 0 or index >= self.item_count():
-      raise KeyError, "invalid index"
+      raise KeyError("invalid index")
     return ColorMap.Item(self.handle, index)
 
   def __getitem__(self, index):

--- a/plugin/install.py
+++ b/plugin/install.py
@@ -25,6 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from future import print_function
 import sys
 import os
 import shutil
@@ -39,12 +40,12 @@ if len(sys.argv) > 1:
       pkg = True
       version = arg[5:]
     else:
-      print "install.py [-pkg=version]"
-      print ""
-      print "  Install Crayfish Python plugin"
-      print ""
-      print "  Arguments:"
-      print "  -pkg      Create a package for upload instead of installing"
+      print("install.py [-pkg=version]")
+      print("")
+      print("  Install Crayfish Python plugin")
+      print("")
+      print("  Arguments:")
+      print("  -pkg      Create a package for upload instead of installing")
       sys.exit(0)
 
 install_files = ['metadata.txt'] + glob.glob("*.py") + glob.glob("*.png") + glob.glob("illuvis/*.py") + glob.glob("doc/*")
@@ -67,12 +68,12 @@ else:
   plugin_dir = os.path.expanduser(os.path.join("~", ".qgis2", "python", "plugins", "crayfish"))
   if not os.path.exists(plugin_dir):
     os.makedirs(plugin_dir)
-  print install_dirs
+  print(install_dirs)
   for subdir in install_dirs:
     subdir_path = os.path.join(plugin_dir, subdir)
     if not os.path.exists(subdir_path): os.makedirs(subdir_path)
-    
+
   for filename in install_files:
-    print "-- "+filename
+    print("-- "+filename)
     destdir = os.path.join(plugin_dir, os.path.dirname(filename))
     shutil.copy(filename, destdir)


### PR DESCRIPTION
Installation instructions (specifically running the `./install.py` step) fail for modern Linux distributions using Python 3 as the default Python interpreter. By using Python 3-style print functions (and ensuring Python 2 compatibility by importing `print_function` from `future`), and changing the `raise` statements to be compatible with both versions [(see here)](http://python-future.org/compatible_idioms.html#raising-exceptions), this plugin can be made future-proof.