### PR TITLE
Animation: Change intermediate image output format: '%03d' -> '%05d'

### DIFF
--- a/crayfish/animation.py
+++ b/crayfish/animation.py
@@ -255,7 +255,7 @@ def prepare_composition(layout, time, cfg, layoutcfg, extent, layers, crs):
         set_item_pos(cLegend, itemcfg['position'], layout)
 
 
-def images_to_video(tmp_img_dir="/tmp/vid/%03d.png", output_file="/tmp/vid/test.avi", fps=10, qual=1,
+def images_to_video(tmp_img_dir="/tmp/vid/%05d.png", output_file="/tmp/vid/test.avi", fps=10, qual=1,
                     ffmpeg_bin="ffmpeg", keep_intermediate_images=False):
     if qual == 0:  # lossless
         opts = ["-vcodec", "ffv1"]

--- a/crayfish/gui/animation_dialog.py
+++ b/crayfish/gui/animation_dialog.py
@@ -228,7 +228,7 @@ class CrayfishAnimationDialog(qtBaseClass, uiDialog):
         w = self.spinWidth.value()
         h = self.spinHeight.value()
         fps = self.spinSpeed.value()
-        img_output_tpl = os.path.join(tmpdir, "%03d.png")
+        img_output_tpl = os.path.join(tmpdir, "%05d.png")
 
         tmpl = None # path to template file to be used
 


### PR DESCRIPTION
With very high resolution data and long time series, 999 images often get exceeded and the order of the resulting animation gets muddled. Therefor the output-image format was increased to 999999.