### PR TITLE
fix time format in processing

### DIFF
--- a/crayfish/processing/parameters.py
+++ b/crayfish/processing/parameters.py
@@ -131,7 +131,7 @@ class TimestepWidgetWrapper(EnumWidgetWrapper):
                     index = QgsMeshDatasetIndex(groupWithMaximumDatasets, i)
                     meta = dp.datasetMetadata(index)
                     time = meta.time()
-                    options.append((str(datetime.timedelta(hours=time)), i))
+                    options.append((mesh_layer.formatTime(time), i))
         else:
             options = []
         self.parameterDefinition().setOptions([t for t, v in options])


### PR DESCRIPTION
Fix rounding time format in the processing widget.
It the mesh layer doesn't have natively a reference time, time is relative.
If it has, time is absolute.
(same logic that static dataset in the mesh layer properties dialog, tab source)