### PR TITLE
workaround for displaying with NaN value

### DIFF
--- a/crayfish/gui/plot_widget.py
+++ b/crayfish/gui/plot_widget.py
@@ -376,10 +376,6 @@ class CrayfishPlotWidget(QWidget):
         self.plot.getAxis('left').setLabel(self.dataset_group_name(ds_group_index))
         self.plot.legend.setVisible(False)
 
-        valid_plot = not all(map(math.isnan, y))
-        if not valid_plot:
-            return
-
         pen = pyqtgraph.mkPen(color=clr, width=2, cosmetic=True)
         return self.plot.plot(x=x, y=y, connect='finite', pen=pen)
 

--- a/crayfish/plot.py
+++ b/crayfish/plot.py
@@ -67,6 +67,7 @@ colors = [
     QColor( "#fdbf6f" ),
 ]
 
+# see https://github.com/pyqtgraph/pyqtgraph/issues/1057
 pyqtGraphAcceptNaN=version.parse(PYQT_VERSION_STR)<version.parse("3.13.1")
 
 def timeseries_plot_data(layer, ds_group_index, geometry, searchradius=0):


### PR DESCRIPTION
a workaround to fix #453 if confirmed:
The NaN value are not added to the array, so the plot is displayed but plot can not be broken anymore if there are value on each side of NaN value. Indeed, before #453 there would be several plot if there are NaN value in the array, with this workaround, it is not the case anymore.
As this workaround can bias integral calculation, for integral the NaN value are still used.
